### PR TITLE
Update to kotlin 1.8.20, dokka 1.8.10, migrated to WorkExecutors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm")
     `java-gradle-plugin`
-    id("com.gradle.plugin-publish") version ("1.1.0")
+    id("com.gradle.plugin-publish") version "1.1.0"
     `maven-publish`
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
 group = "io.github.devcrocod"
@@ -36,28 +36,17 @@ val kotlin_version: String by project
 dependencies {
     shadow(kotlin("stdlib-jdk8", version = kotlin_version))
     shadow("org.jetbrains.dokka:dokka-core:$dokka_version")
+    shadow("org.jetbrains.dokka:dokka-analysis:$dokka_version")
 
-    compileOnly(gradleApi())
-    implementation("org.jetbrains.dokka:dokka-analysis:$dokka_version")
+    shadow(gradleApi())
+    shadow(gradleKotlinDsl())
 }
 
-tasks {
-    shadowJar {
-        relocate("com.intellij", "io.github.devcrocod.com.intellij")
-        relocate("org.jetbrains.kotlin", "io.github.devcrocod.org.jetbrains.kotlin")
-        mergeServiceFiles()
-
-        archiveClassifier.set("")
-        dependencies {
-            exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib"))
-            exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib-jdk8"))
-            exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib-jdk7"))
-            exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib-common"))
-            exclude(dependency("org.jetbrains:annotations"))
-            exclude(dependency("org.jetbrains.dokka:dokka-core:$dokka_version"))
-        }
-    }
+tasks.shadowJar {
+    isZip64 = true
+    archiveClassifier.set("")
 }
+
 
 tasks.jar {
     enabled = false
@@ -95,4 +84,15 @@ gradlePlugin {
             tags.set(listOf("kotlin", "documentation", "markdown"))
         }
     }
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+    targetCompatibility = JavaVersion.VERSION_1_8.toString()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 kotlin.code.style=official
 
-version=0.1.3
+version=0.1.4
 
-kotlin_version=1.8.10
-language_version=1.7
-dokka_version=1.7.20
+kotlin_version=1.8.20
+language_version=1.8
+dokka_version=1.8.10
 pluginPublishVersion=0.15.0

--- a/src/main/kotlin/io/github/devcrocod/korro/KorroAction.kt
+++ b/src/main/kotlin/io/github/devcrocod/korro/KorroAction.kt
@@ -9,6 +9,7 @@ import java.io.File
 interface KorroParameters : WorkParameters {
     var docs: Set<File>
     var samples: Set<File>
+    var groups: List<SamplesGroup>
     var name: String
 }
 
@@ -18,6 +19,7 @@ abstract class KorroAction : WorkAction<KorroParameters> {
     abstract val ext: KorroExtension
 
     override fun execute() {
+        ext.groups.addAll(parameters.groups)
         val ctx = ext.createContext(parameters.docs, parameters.samples)
 
         //TODO - check missing files!

--- a/src/main/kotlin/io/github/devcrocod/korro/KorroAction.kt
+++ b/src/main/kotlin/io/github/devcrocod/korro/KorroAction.kt
@@ -1,0 +1,52 @@
+package io.github.devcrocod.korro
+
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Nested
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import java.io.File
+
+interface KorroParameters : WorkParameters {
+    var docs: Set<File>
+    var samples: Set<File>
+    var name: String
+}
+
+abstract class KorroAction : WorkAction<KorroParameters> {
+
+    @get:Nested
+    abstract val ext: KorroExtension
+
+    override fun execute() {
+        val ctx = ext.createContext(parameters.docs, parameters.samples)
+
+        //TODO - check missing files!
+
+        //TODO - process!!! error
+        if (!ctx.process()) {
+            val extra = if (ctx.logger.nOutdated > 0)
+                "\nRun 'korro' task to write ${ctx.logger.nOutdated} missing/outdated files."
+            else
+                ""
+            throw GradleException("${parameters.name} task failed, see log for details (use '--info' for detailed log).$extra")
+        }
+    }
+}
+
+abstract class KorroCleanAction : WorkAction<KorroParameters> {
+
+    @get:Nested
+    abstract val ext: KorroExtension
+
+    override fun execute() {
+        val ctx = ext.createContext(parameters.docs, parameters.samples)
+
+        if (!ctx.processClean()) {
+            val extra = if (ctx.logger.nOutdated > 0)
+                "\nRun 'korro' task to write ${ctx.logger.nOutdated} missing/outdated files."
+            else
+                ""
+            throw GradleException("${parameters.name} task failed, see log for details (use '--info' for detailed log).$extra")
+        }
+    }
+}

--- a/src/main/kotlin/io/github/devcrocod/korro/KorroExtension.kt
+++ b/src/main/kotlin/io/github/devcrocod/korro/KorroExtension.kt
@@ -49,7 +49,7 @@ abstract class KorroExtension {
     var docs: FileCollection? = null
     var samples: FileCollection? = null
 
-    private val groups = mutableListOf<SamplesGroup>()
+    internal val groups = mutableListOf<SamplesGroup>()
 
     @Nested
     abstract fun getGroupSamples(): GroupSamplesApi

--- a/src/main/kotlin/io/github/devcrocod/korro/KorroTask.kt
+++ b/src/main/kotlin/io/github/devcrocod/korro/KorroTask.kt
@@ -43,6 +43,9 @@ private interface KorroTasksCommon {
 
     var samples: FileCollection
 
+    @get:Internal
+    val groups: List<SamplesGroup>
+
     fun execute(clazz: Class<out WorkAction<KorroParameters>>) {
         val workQueue = workerExecutor.classLoaderIsolation {
             it.classpath.setFrom(classpath.resolve())
@@ -50,6 +53,7 @@ private interface KorroTasksCommon {
         workQueue.submit(clazz) {
             it.docs = docs.files
             it.samples = samples.files
+            it.groups = groups
             it.name = nameReference
         }
     }
@@ -68,6 +72,9 @@ abstract class KorroTask : DefaultTask(), KorroTasksCommon {
     override var samples: FileCollection = ext.samples ?: project.fileTree(project.rootDir) {
         it.include("**/*.kt")
     }
+
+    @get:Internal
+    override val groups: List<SamplesGroup> = ext.groups
 
     @get:Internal
     override val projectReference: Project
@@ -95,6 +102,9 @@ abstract class KorroCleanTask : Delete(), KorroTasksCommon {
     override var samples: FileCollection = ext.samples ?: project.fileTree(project.rootDir) {
         it.include("**/*.kt")
     }
+
+    @get:Internal
+    override val groups: List<SamplesGroup> = ext.groups
 
     @get:Internal
     override val projectReference: Project

--- a/src/main/kotlin/io/github/devcrocod/korro/KorroTask.kt
+++ b/src/main/kotlin/io/github/devcrocod/korro/KorroTask.kt
@@ -1,65 +1,114 @@
 package io.github.devcrocod.korro
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
-import org.gradle.api.tasks.Delete
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
 
-abstract class KorroTask : DefaultTask() {
-    private val ext: KorroExtension = project.extensions.getByType(KorroExtension::class.java)
+// TODO get from central version
+const val dokkaVersion = "1.8.10"
+private interface KorroTasksCommon {
+
+    @get:Internal
+    val projectReference: Project
+
+    @get:Internal
+    val nameReference: String
+
+    @get:Classpath
+    val classpath: Configuration
+        get() = projectReference.configurations.maybeCreate("korroRuntime") {
+            isCanBeConsumed = true
+            listOf(
+                "org.jetbrains.dokka:dokka-analysis",
+                "org.jetbrains.dokka:dokka-base",
+                "org.jetbrains.dokka:dokka-core",
+            ).forEach {
+                dependencies += projectReference.dependencies.create("$it:$dokkaVersion")
+            }
+        }
+
+    @get:Inject
+    val workerExecutor: WorkerExecutor
+
+    @get:Internal
+    val ext: KorroExtension
+
+    var docs: FileCollection
+
+    var samples: FileCollection
+
+    fun execute(clazz: Class<out WorkAction<KorroParameters>>) {
+        val workQueue = workerExecutor.classLoaderIsolation {
+            it.classpath.setFrom(classpath.resolve())
+        }
+        workQueue.submit(clazz) {
+            it.docs = docs.files
+            it.samples = samples.files
+            it.name = nameReference
+        }
+    }
+}
+
+abstract class KorroTask : DefaultTask(), KorroTasksCommon {
+
+    final override val ext: KorroExtension = project.extensions.getByType(KorroExtension::class.java)
 
     @InputFiles
-    var docs: FileCollection = ext.docs ?: project.fileTree(project.rootDir) {
+    override var docs: FileCollection = ext.docs ?: project.fileTree(project.rootDir) {
         it.include("**/*.md")
     }
 
     @InputFiles
-    var samples: FileCollection = ext.samples ?: project.fileTree(project.rootDir) {
+    override var samples: FileCollection = ext.samples ?: project.fileTree(project.rootDir) {
         it.include("**/*.kt")
     }
+
+    @get:Internal
+    override val projectReference: Project
+        get() = project
+
+    @get:Internal
+    override val nameReference: String
+        get() = name
 
     @TaskAction
     fun korro() {
-        val ctx = ext.createContext(docs.files, samples.files)
-
-        //TODO - check missing files!
-
-        //TODO - process!!! error
-        if (!ctx.process()) {
-            val extra = if (ctx.logger.nOutdated > 0)
-                "\nRun 'korro' task to write ${ctx.logger.nOutdated} missing/outdated files."
-            else
-                ""
-            throw GradleException("$name task failed, see log for details (use '--info' for detailed log).$extra")
-        }
+        execute(KorroAction::class.java)
     }
 }
 
-abstract class KorroCleanTask : Delete() {
-    private val ext: KorroExtension = project.extensions.getByType(KorroExtension::class.java)
+abstract class KorroCleanTask : Delete(), KorroTasksCommon {
+    final override val ext: KorroExtension = project.extensions.getByType(KorroExtension::class.java)
 
     @InputFiles
-    var docs: FileCollection = ext.docs ?: project.fileTree(project.rootDir) {
+    override var docs: FileCollection = ext.docs ?: project.fileTree(project.rootDir) {
         it.include("**/*.md")
     }
 
     @InputFiles
-    var samples: FileCollection = ext.samples ?: project.fileTree(project.rootDir) {
+    override var samples: FileCollection = ext.samples ?: project.fileTree(project.rootDir) {
         it.include("**/*.kt")
     }
 
+    @get:Internal
+    override val projectReference: Project
+        get() = project
+
+    @get:Internal
+    override val nameReference: String
+        get() = name
+
     @TaskAction
     fun korroClean() {
-        val ctx = ext.createContext(docs.files, samples.files)
-
-        if (!ctx.processClean()) {
-            val extra = if (ctx.logger.nOutdated > 0)
-                "\nRun 'korro' task to write ${ctx.logger.nOutdated} missing/outdated files."
-            else
-                ""
-            throw GradleException("$name task failed, see log for details (use '--info' for detailed log).$extra")
-        }
+        execute(KorroCleanAction::class.java)
     }
 }
+
+private fun <T : Any> NamedDomainObjectContainer<T>.maybeCreate(name: String, configuration: T.() -> Unit): T =
+    findByName(name) ?: create(name, configuration)

--- a/src/main/kotlin/io/github/devcrocod/korro/SampleGroups.kt
+++ b/src/main/kotlin/io/github/devcrocod/korro/SampleGroups.kt
@@ -1,6 +1,8 @@
 package io.github.devcrocod.korro
 
-data class FunctionPattern(val nameSuffix: String, val substitutions: Map<String, String>) {
+import java.io.Serializable
+
+data class FunctionPattern(val nameSuffix: String, val substitutions: Map<String, String>): Serializable {
     fun processSubstitutions(text: String) = substitutions.entries.fold(text) { acc, entry ->
         acc.replace(entry.key, entry.value)
     }
@@ -12,4 +14,4 @@ data class SamplesGroup(
     val beforeSample: String?,
     val afterSample: String?,
     val patterns: List<FunctionPattern>
-)
+) : Serializable

--- a/src/main/kotlin/io/github/devcrocod/korro/SamplesTransformer.kt
+++ b/src/main/kotlin/io/github/devcrocod/korro/SamplesTransformer.kt
@@ -9,7 +9,6 @@ import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.dokka.Platform
 import org.jetbrains.dokka.analysis.AnalysisEnvironment
 import org.jetbrains.dokka.analysis.DokkaResolutionFacade
-import org.jetbrains.dokka.analysis.EnvironmentAndFacade
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
@@ -168,14 +167,14 @@ class SamplesTransformer(private val context: KorroContext) {
     }
 
     operator fun invoke(functionName: String): String? {
-        val facade = setUpAnalysis().facade
+        val facade = setUpAnalysis()
         val psiElement = fqNameToPsiElement(facade, functionName)
             ?: return null//.also { context.logger.warn("Cannot find PsiElement corresponding to $functionName") }
         val body = processBody(psiElement)
         return createSampleBody(body)
     }
 
-    private fun setUpAnalysis(): EnvironmentAndFacade =
+    private fun setUpAnalysis(): DokkaResolutionFacade =
         AnalysisEnvironment(KorroMessageCollector(context.logger), Platform.jvm).run {
             addClasspath(PathUtil.getJdkClassesRootsFromCurrentJre())
             addSources(context.sampleSet.toList())
@@ -183,7 +182,7 @@ class SamplesTransformer(private val context: KorroContext) {
 
             val environment = createCoreEnvironment()
             val (facade, _) = createResolutionFacade(environment)
-            EnvironmentAndFacade(environment, facade)
+            facade
         }
 
     private fun createSampleBody(body: String) =


### PR DESCRIPTION
In [DataFrame](https://github.com/Kotlin/dataframe), we had issues with conflicting Kotlin compiler versions. These issues I fixed in my [Doc Processor Plugin](https://github.com/Jolanrensen/docProcessorGradlePlugin) by migrating to WorkExecutors, essentially creating a sandbox Gradle instance that can have its own dependencies without cluttering those of the project using the plugin. This PR fixes that, as well as updating versions for Kotlin and Dokka.